### PR TITLE
Check if line is not a comment before parse

### DIFF
--- a/src/Env.php
+++ b/src/Env.php
@@ -27,7 +27,7 @@ class Env {
 
         foreach ($env_lines as $line)
         {
-            if (strlen($line)) {
+            if (strlen($line) && str_contains((string) $line, '=')) {
                 [$key, $val] = explode('=', (string)$line);
                 $this->_envVars[$key] = $this->_stripValue($val);
             }


### PR DESCRIPTION
Fixed: If the lines on the .env does not have a '=' char the explode and list() will failt

https://github.com/msztorc/laravel-env/issues/1